### PR TITLE
Expanded API, exposing map as unmodifiable collection…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/bin/
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,12 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.22</version>
         </dependency>
+        <dependency>
+		    <groupId>junit</groupId>
+		    <artifactId>junit</artifactId>
+		    <version>4.12</version>
+		    <scope>test</scope>
+		</dependency>
     </dependencies>
          
     <build>

--- a/src/main/java/com/github/silk8192/reflector/ClassFileManager.java
+++ b/src/main/java/com/github/silk8192/reflector/ClassFileManager.java
@@ -4,64 +4,157 @@ import org.apache.commons.io.FilenameUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.function.Predicate;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 /**
- * Handles the loading of classes from either a local .jar file or the root directory of many classes.
- *
- * @author silk8192
+ * Handles the loading of classes from either a local .jar file and/or the root directory of many classes.
+ * @author silk8192, acrois
  */
 public class ClassFileManager {
+    private final Map<String, Class<?>> classes = new HashMap<>();
+    private final Map<String, Class<?>> classesReadOnly = Collections.unmodifiableMap(classes);
 
-    private HashMap<String, Class<?>> classes = new HashMap<>();
+    // you probably wouldn't want an empty constructor, however we can slim down the code a little so it's easier to read.
 
-    public ClassFileManager(File jarFile) {
-        try {
-            URLClassLoader loader = new URLClassLoader(new URL[]{jarFile.toPath().toUri().toURL()});
-            Enumeration entries = new ZipFile(jarFile).entries();
-            while (entries.hasMoreElements()) {
-                ZipEntry entry = (ZipEntry) entries.nextElement();
-                if (FilenameUtils.getExtension(entry.getName()).equals("class") && !entry.getName().contains("$")) {
-                    String className = entry.getName().replace("\\", ".").replace(".class", "").replace("/", ".");
-                    this.classes.put(className, loader.loadClass(className));
+    /**
+     * Initializes with the supplied starting file.
+     * @param start The root file or JAR file.
+     * @throws IOException
+     */
+    public ClassFileManager(File start) throws IOException {
+        this(start.toPath(), true);
+    }
+    
+    /**
+     * Initializes with the supplied starting file.
+     * @param start The root file or JAR file.
+     * @throws IOException
+     */
+    public ClassFileManager(Path start) throws IOException {
+        this(start, true);
+    }
+    
+    /**
+     * Initializes with the supplied starting file.
+     * @param start The root file or JAR file.
+     * @param loadJar True to load .jar files, false otherwise.
+     * @throws IOException
+     */
+    public ClassFileManager(File start, boolean loadJar) throws IOException {
+        this(start.toPath(), loadJar);
+    }
+
+    /**
+     * Initializes with the supplied starting file.
+     * @param start The root file or JAR file.
+     * @param loadJar True to load .jar files, false otherwise.
+     * @throws IOException
+     */
+    public ClassFileManager(Path start, boolean loadJar) throws IOException {
+        addAll(start, loadJar);
+    }
+
+    /**
+     * A read-only mapping of the classes.
+     * @return The mapping of class names to class types.
+     */
+    public Map<String, Class<?>> getClasses() {
+        return classesReadOnly;
+    }
+
+    /**
+     * Gets a class type 
+     * @param canonicalClassName
+     * @return The type, or null if does not exist.
+     * @see {@link java.util.Map#get(Object)}
+     */
+    public Class<?> getClass(String canonicalClassName) {
+        return classesReadOnly.get(canonicalClassName);
+    }
+    
+    /**
+     * Loads a single class file or classes from .jar file.
+     * @param path
+     * @throws IOException
+     */
+    public void add(Path path) throws IOException {
+        String name = path.toFile().getName();
+
+        if (FilenameUtils.getExtension(name).equals("jar")) {
+            try (
+                URLClassLoader loader = new URLClassLoader(new URL[] { path.toUri().toURL() });
+                ZipFile zf = new ZipFile(path.toFile())
+            ) {
+                Enumeration<? extends ZipEntry> entries = zf.entries();
+
+                while (entries.hasMoreElements()) {
+                    ZipEntry entry = (ZipEntry) entries.nextElement();
+
+                    if (FilenameUtils.getExtension(entry.getName()).equals("class") && !entry.getName().contains("$")) {
+                        String className = entry.getName().replace(".class", "").replace("\\", ".").replace("/", ".");
+
+                        try {
+                            classes.put(className, loader.loadClass(className));
+                        } catch (ClassNotFoundException ex) {
+                            ex.printStackTrace(); // hmm
+                        }
+                    }
                 }
             }
-        } catch (IOException | ClassNotFoundException e) {
-            e.printStackTrace();
+        }
+        else if (FilenameUtils.getExtension(name).equals("class") && !name.contains("$")) {
+            String className = FilenameUtils.removeExtension(path.toString());
+            className = className.replace("\\", "."); // replace forward slashes in path to "."
+            URL i = path.toUri().toURL();
+            
+            try (URLClassLoader loader = new URLClassLoader(new URL[] { i })) {
+                classes.put(className, loader.loadClass(className));
+            } catch (ClassNotFoundException ex) {
+                ex.printStackTrace(); // hmm
+            }
         }
     }
 
-    public ClassFileManager(Path classPath) {
-        try {
-            Predicate<Path> fileFilter = f -> Files.isRegularFile(f.toAbsolutePath()) && FilenameUtils.getExtension(f.toString()).equals("class");
-            Files.walk(classPath).filter(fileFilter)
-                    .forEach(classFile -> {
-                        String className = FilenameUtils.removeExtension(classPath.relativize(classFile).toString());
-                        //replace forward slashes in path to "."
-                        className = className.replace("\\", ".");
-                        try {
-                            ClassLoader cr = new URLClassLoader(new URL[]{classFile.toUri().toURL()});
-                            Class<?> classFileObject = cr.loadClass(className);
-                            classes.put(className, classFileObject);
-                        } catch (MalformedURLException | ClassNotFoundException e) {
-                            e.printStackTrace();
-                        }
-                    });
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+    /**
+     * Walks through this {@link Path}'s file tree and visits each {@link Path}, including all .class files in folders starting at the specified path. By default, .jar files will be included, and so will the classes that reside in the folders inside.
+     * @param path The path to start at.
+     * @throws IOException
+     * @see {@link com.github.silk8192.reflector.ClassFileManager#addAll(Path, boolean)}
+     */
+    public void addAll(Path path) throws IOException {
+        addAll(path, true);
     }
-
-    public Class<?> getClass(String canonicalClassName) {
-        return this.classes.get(canonicalClassName);
+    
+    /**
+     * Walks through the file tree and visits each {@link Path}, including all .class files in folders starting at the specified path. If allowed, .jar files will be included, and so will the classes that reside in the folders inside.
+     * @param path The path to start at.
+     * @param loadJar True to load .jar files, false to skip them.
+     * @throws IOException
+     * @see {@link com.github.silk8192.reflector.ClassFileManager#add(Path)}
+     */
+    public void addAll(Path path, boolean loadJar) throws IOException {
+        Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                if (!loadJar && FilenameUtils.isExtension(file.toFile().getName(), "jar")) {
+                    return FileVisitResult.CONTINUE;
+                }
+                
+                add(path.relativize(file));
+                return FileVisitResult.CONTINUE;
+            }
+        });
     }
 }

--- a/src/test/com/github/silk8192/reflector/ClassFileManagerTest.java
+++ b/src/test/com/github/silk8192/reflector/ClassFileManagerTest.java
@@ -1,0 +1,26 @@
+package com.github.silk8192.reflector;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ClassFileManagerTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+    
+    @Test
+    public void addAllFromTest() throws IOException, URISyntaxException {
+        Class<?> s = getClass(); // in this test, we get our own class
+        Path k = Paths.get(s.getProtectionDomain().getCodeSource().getLocation().toURI());  // find our where it's located
+        ClassFileManager cfm = new ClassFileManager(k);
+        Class<?> c = cfm.getClass(this.getClass().getCanonicalName()); // see if we can find a class by our own name
+        Assert.assertEquals(s, c); // if we can find our own class, it's a success!
+    }
+}


### PR DESCRIPTION
So that users can get all the classes via `getClasses()` and utilize the `Map` interface. Included unit testing for `ClassFileManager`, `JUnit` as a dependency in the test scope.

Adds various add* methods. Constructors have been modified but signatures are not changed.