### PR TITLE
Fix IllegalArgumentException

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ cfm.getClass("foo.Bar");
 
 ## Dependencies:
 * SLF4j Logging
-* Commons-io
 
 ## License:
 This project is under the MIT license. See the ```LICENSE``` file for terms.

--- a/src/main/java/com/github/silk8192/reflector/Reflector.java
+++ b/src/main/java/com/github/silk8192/reflector/Reflector.java
@@ -105,7 +105,7 @@ public class Reflector {
                 logger.info("Method does not match argument types!");
                 throw new NoSuchMethodException();
             } else if (method.getReturnType() == void.class) {
-                method.invoke(object);
+                method.invoke(object, args);
                 return new Reflector(object);
             } else {
                 return new Reflector(method.invoke(object, args));
@@ -115,7 +115,7 @@ public class Reflector {
                 if (method.getName().equals(name) && checkArgumentTypes(method.getParameterTypes(), types)) {
                     try {
                         if (method.getReturnType() == void.class) {
-                            method.invoke(object);
+                            method.invoke(object, args);
                             return new Reflector(object);
                         } else {
                             return new Reflector(method.invoke(object, args));


### PR DESCRIPTION
Following scenario would cause an Exception:

```java
import static com.github.silk8192.reflector.Reflector.*;

public class Example {
    public void sayHello(String name) {
        System.out.printf("Hello %s%n", name);
    }

    public static void main(String[] args) {
        forClass(Example.class).create(null).invoke("sayHello", "Selim");
    }    
}
```

The method expects a String but in Reflector.java:118 it would have been called without any arguments thus causing an IllegalArgumentException.